### PR TITLE
Rewrote ExpressionSyntaxRewriter to handle @this rewrites more reliably

### DIFF
--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMemberExplicitReference.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMemberExplicitReference.verified.txt
@@ -1,0 +1,15 @@
+using EntityFrameworkCore.Projectables;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_Derived_Bar
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.Derived, string>> Expression()
+        {
+            return (global::Projectables.Repro.Derived @this) => 
+                @this.Foo;
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMemberImplicitReference.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMemberImplicitReference.verified.txt
@@ -1,0 +1,15 @@
+using EntityFrameworkCore.Projectables;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_Derived_Bar
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.Derived, string>> Expression()
+        {
+            return (global::Projectables.Repro.Derived @this) => 
+                @this.Foo;
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMethodExplicitReference.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMethodExplicitReference.verified.txt
@@ -1,0 +1,15 @@
+using EntityFrameworkCore.Projectables;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_Derived_Bar
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.Derived, string>> Expression()
+        {
+            return (global::Projectables.Repro.Derived @this) => 
+                @this.Foo();
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMethorImplicitReference.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.BaseMethorImplicitReference.verified.txt
@@ -1,0 +1,15 @@
+using EntityFrameworkCore.Projectables;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_Derived_Bar
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.Derived, string>> Expression()
+        {
+            return (global::Projectables.Repro.Derived @this) => 
+                @this.Foo();
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.FooOrBar.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.FooOrBar.verified.txt
@@ -1,0 +1,16 @@
+using EntityFrameworkCore.Projectables;
+using System.Collections.Generic;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_SomeEntity_FooOrBar
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.SomeEntity, string>> Expression()
+        {
+            return (global::Projectables.Repro.SomeEntity @this) => 
+                @this.Foo != null ? @this.Foo : @this.Bar;
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.NavigationProperties.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.NavigationProperties.verified.txt
@@ -1,0 +1,16 @@
+using EntityFrameworkCore.Projectables;
+using System.Collections.Generic;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_SomeEntity_RootChildren
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.SomeEntity, ICollection<global::Projectables.Repro.SomeEntity>>> Expression()
+        {
+            return (global::Projectables.Repro.SomeEntity @this) => 
+                @this.Parent != null ? @this.Parent.RootChildren : @this.Children;
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.ParentNavigation.received.txt
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.ParentNavigation.received.txt
@@ -1,0 +1,16 @@
+using EntityFrameworkCore.Projectables;
+using System.Collections.Generic;
+using Projectables.Repro;
+
+namespace EntityFrameworkCore.Projectables.Generated
+#nullable disable
+{
+    public static class Projectables_Repro_SomeEntity_ParentOrThis
+    {
+        public static System.Linq.Expressions.Expression<System.Func<global::Projectables.Repro.SomeEntity, global::Projectables.Repro.SomeEntity>> Expression()
+        {
+            return (global::Projectables.Repro.SomeEntity @this) => 
+                @this.        Parent != null ? @this.Parent : this;
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.cs
+++ b/tests/EntityFrameworkCore.Projectables.Generator.Tests/ProjectionExpressionGeneratorTests.cs
@@ -1227,6 +1227,180 @@ public static class SomeExtensions
             return Verifier.Verify(result.GeneratedTrees[0].ToString());
         }
 
+        [Fact]
+        public Task NavigationProperties()
+        {
+            var compilation = CreateCompilation(@"
+using EntityFrameworkCore.Projectables;
+using System.Collections.Generic;
+
+namespace Projectables.Repro;
+
+public class SomeEntity
+{
+    public int Id { get; set; }
+
+    public SomeEntity Parent { get; set; }
+
+    public ICollection<SomeEntity> Children { get; set; }
+
+    [Projectable]
+    public ICollection<SomeEntity> RootChildren =>
+        Parent != null ? Parent.RootChildren : Children;
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
+        [Fact]
+        public Task FooOrBar()
+        {
+            var compilation = CreateCompilation(@"
+using EntityFrameworkCore.Projectables;
+using System.Collections.Generic;
+
+namespace Projectables.Repro;
+
+public class SomeEntity
+{
+    public int Id { get; set; }
+
+    public string Foo { get; set; }
+
+    public string Bar { get; set; }
+
+    [Projectable]
+    public string FooOrBar =>
+        Foo != null ? Foo : Bar;
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
+        [Fact]
+        public Task BaseMemberExplicitReference()
+        {
+            var compilation = CreateCompilation(@"
+using EntityFrameworkCore.Projectables;
+
+namespace Projectables.Repro;
+
+class Base 
+{
+    public string Foo { get; set; }
+}
+
+class Derived : Base
+{
+    [Projectable]
+    public string Bar => base.Foo;
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
+        [Fact]
+        public Task BaseMemberImplicitReference()
+        {
+            var compilation = CreateCompilation(@"
+using EntityFrameworkCore.Projectables;
+
+namespace Projectables.Repro;
+
+class Base 
+{
+    public string Foo { get; set; }
+}
+
+class Derived : Base
+{
+    [Projectable]
+    public string Bar => Foo;
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
+        [Fact]
+        public Task BaseMethodExplicitReference()
+        {
+            var compilation = CreateCompilation(@"
+using EntityFrameworkCore.Projectables;
+
+namespace Projectables.Repro;
+
+class Base 
+{
+    public string Foo() => """";
+}
+
+class Derived : Base
+{
+    [Projectable]
+    public string Bar => base.Foo();
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
+        [Fact]
+        public Task BaseMethorImplicitReference()
+        {
+            var compilation = CreateCompilation(@"
+using EntityFrameworkCore.Projectables;
+
+namespace Projectables.Repro;
+
+class Base 
+{
+    public string Foo() => """";
+}
+
+class Derived : Base
+{
+    [Projectable]
+    public string Bar => Foo();
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
         #region Helpers
 
         Compilation CreateCompilation(string source, bool expectedToCompile = true)


### PR DESCRIPTION
Before, implicit receiver calls were unreliable and only worked in some cases. This rewrite should make it more reliable.