### PR TITLE
UseMemberBody to use the body of another member

### DIFF
--- a/src/EntityFrameworkCore.Projectables.Abstractions/ProjectableAttribute.cs
+++ b/src/EntityFrameworkCore.Projectables.Abstractions/ProjectableAttribute.cs
@@ -17,5 +17,11 @@ namespace EntityFrameworkCore.Projectables
         /// Get or set how null-conditional operators are handeled
         /// </summary>
         public NullConditionalRewriteSupport NullConditionalRewriteSupport { get; set; }
+
+        /// <summary>
+        /// Get or set from which member to get the expression,
+        /// or null to get it from the current member.
+        /// </summary>
+        public string? UseMemberBody { get; set; }
     }
 }

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/UseMemberBodyPropertyTests.UseMemberPropertyExpression.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/UseMemberBodyPropertyTests.UseMemberPropertyExpression.verified.txt
@@ -1,0 +1,2 @@
+SELECT [e].[Id] * 3
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/UseMemberBodyPropertyTests.UseMemberPropertyGenerated.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/UseMemberBodyPropertyTests.UseMemberPropertyGenerated.verified.txt
@@ -1,0 +1,2 @@
+SELECT [e].[Id] * 2
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/UseMemberBodyPropertyTests.cs
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/UseMemberBodyPropertyTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Projectables.FunctionalTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using ScenarioTests;
+using VerifyXunit;
+using Xunit;
+
+namespace EntityFrameworkCore.Projectables.FunctionalTests
+{
+    [UsesVerify]
+    public class UseMemberBodyPropertyTests
+    {
+        public record Entity
+        {
+            public int Id { get; set; }
+            
+            [Projectable(UseMemberBody = nameof(Computed2))]
+            public int Computed1 => Id;
+
+            private int Computed2 => Id * 2;
+
+            [Projectable(UseMemberBody = nameof(Computed4))]
+            public int Computed3 => Id;
+
+            private static Expression<Func<Entity, int>> Computed4 => x => x.Id * 3;
+        }
+
+        [Fact]
+        public Task UseMemberPropertyGenerated()
+        {
+            using var dbContext = new SampleDbContext<Entity>();
+
+            var query = dbContext.Set<Entity>()
+                .Select(x => x.Computed1);
+
+            return Verifier.Verify(query.ToQueryString());
+        }
+
+        [Fact]
+        public Task UseMemberPropertyExpression()
+        {
+            using var dbContext = new SampleDbContext<Entity>();
+
+            var query = dbContext.Set<Entity>()
+                .Select(x => x.Computed3);
+
+            return Verifier.Verify(query.ToQueryString());
+        }
+    }
+}


### PR DESCRIPTION
This change resolves #25, supporting two diffent approaches.

```c#
        public record Entity
        {
            public int Id { get; set; }
            
            [Projectable(UseMemberBody = nameof(Computed2))]
            public int Computed1 => Id;

            private int Computed2 => Id * 2;

            [Projectable(UseMemberBody = nameof(Computed4))]
            public int Computed3 => Id;

            private static Expression<Func<Entity, int>> Computed4 => x => x.Id * 3;
        }
```

Code written for properties and methods, although I have only tested for properties. Xunit tests included.

This change also adds the member full path to the error message for #26. It can be improved further, though.