### PR TITLE
Ensure generated file name hints have the .g.cs extension

### DIFF
--- a/src/EntityFrameworkCore.Projectables.Generator/ProjectionExpressionGenerator.cs
+++ b/src/EntityFrameworkCore.Projectables.Generator/ProjectionExpressionGenerator.cs
@@ -158,7 +158,7 @@ namespace EntityFrameworkCore.Projectables.Generated
 }}");
 
 
-                context.AddSource($"{generatedClassName}_Generated", SourceText.From(resultBuilder.ToString(), Encoding.UTF8));
+                context.AddSource($"{generatedClassName}.g.cs", SourceText.From(resultBuilder.ToString(), Encoding.UTF8));
             }
         }
 


### PR DESCRIPTION
Fixes #47 