### PR TITLE
Add support for interfaces in generic methods

### DIFF
--- a/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
+++ b/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
@@ -42,7 +42,7 @@ namespace EntityFrameworkCore.Projectables.Services
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             // Get the overriding methodInfo based on te type of the received of this expression
-            var methodInfo = node.Object?.Type.GetOverridingMethod(node.Method) ?? node.Method;
+            var methodInfo = node.Object?.Type.GetConcreteMethod(node.Method) ?? node.Method;
 
             if (TryGetReflectedExpression(methodInfo, out var reflectedExpression))
             {
@@ -74,16 +74,23 @@ namespace EntityFrameworkCore.Projectables.Services
 
         protected override Expression VisitMember(MemberExpression node)
         {
-            var nodeMember = node.Expression switch {
-                { Type: {  } } => node.Expression.Type.GetMember(node.Member.Name, node.Member.MemberType, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)[0],
+            var nodeExpression = node.Expression switch {
+                UnaryExpression { NodeType: ExpressionType.Convert, Type: { IsInterface: true } type, Operand: { } operand }
+                    when type.IsAssignableFrom(operand.Type)
+                    => operand,
+                _ => node.Expression
+            };
+            var nodeMember = node.Member switch {
+                PropertyInfo property when nodeExpression is not null
+                    => nodeExpression.Type.GetConcreteProperty(property),
                 _ => node.Member
             };
 
             if (TryGetReflectedExpression(nodeMember, out var reflectedExpression))
             {
-                if (node.Expression is not null)
+                if (nodeExpression is not null)
                 {
-                    _expressionArgumentReplacer.ParameterArgumentMapping.Add(reflectedExpression.Parameters[0], node.Expression);
+                    _expressionArgumentReplacer.ParameterArgumentMapping.Add(reflectedExpression.Parameters[0], nodeExpression);
                     var updatedBody = _expressionArgumentReplacer.Visit(reflectedExpression.Body);
                     _expressionArgumentReplacer.ParameterArgumentMapping.Clear();
 

--- a/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
+++ b/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
@@ -77,6 +77,8 @@ namespace EntityFrameworkCore.Projectables.Services
             var nodeExpression = node.Expression switch {
                 UnaryExpression { NodeType: ExpressionType.Convert, Type: { IsInterface: true } type, Operand: { } operand }
                     when type.IsAssignableFrom(operand.Type)
+                    // This is an interface member. Operand contains the concrete (or at least more concrete) expression,
+                    // from which we can try to find the concrete member.
                     => operand,
                 _ => node.Expression
             };

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverImplementedMethod.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverImplementedMethod.verified.txt
@@ -1,0 +1,2 @@
+SELECT 2
+FROM [Concrete] AS [c]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverImplementedProperty.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverImplementedProperty.verified.txt
@@ -1,0 +1,2 @@
+SELECT 2
+FROM [Concrete] AS [c]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverInheritedMethodImplementation.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverInheritedMethodImplementation.verified.txt
@@ -1,2 +1,2 @@
 SELECT 2
-FROM [Concrete] AS [c]
+FROM [MoreConcrete] AS [m]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverInheritedPropertyImplementation.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.ProjectOverInheritedPropertyImplementation.verified.txt
@@ -1,2 +1,2 @@
 SELECT 2
-FROM [Concrete] AS [c]
+FROM [MoreConcrete] AS [m]


### PR DESCRIPTION
This way, an expression in a generic method that references an interface member can be translated as long as the runtime generic argument is a concrete type. For example:

```csharp
public static IQueryable<int> SelectComputedProperty<TConcrete>(this IQueryable<TConcrete> concretes)
    where TConcrete : InheritedModelTests.IBase
    => concretes.Select(x => x.ComputedProperty);
```
Here, when `SelectComputedProperty` is called like `SelectComputedProperty<InheritedModelTests.Concrete>` (where the argument can be implicit like in [InheritedModelTests.cs](tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.cs)), the correct implementation method can be found in `Concrete`. 
However, when it is called like `SelectComputedProperty<InheritedModelTests.IBase>`, the concrete implementation is unknown and the method can't be translated.

I also changed overriding member logic (from #52) to use `MethodInfo.GetBaseDefinition()` instead of the name and signature of the method.

I changed some tests, because there were two duplicate tests in [InheritedModelTests.cs](tests/EntityFrameworkCore.Projectables.FunctionalTests/InheritedModelTests.cs). I assumed these modifications were the original intention.

Possible improvements:
- Additions to documentation
- Maybe some extra tests
- Helpful user feedback, like throwing an error when the generic argument is an interface (and thus can't be translated)

Thanks for creating and maintaining this package!