### PR TITLE
Add support for projecting method groups

### DIFF
--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/MethodGroupTests.ProjectOverMethodGroup.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/MethodGroupTests.ProjectOverMethodGroup.verified.txt
@@ -1,0 +1,4 @@
+SELECT [e].[Id], [e0].[Id] + 1, [e0].[Id]
+FROM [Entity] AS [e]
+LEFT JOIN [Entity] AS [e0] ON [e].[Id] = [e0].[EntityId]
+ORDER BY [e].[Id]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/MethodGroupTests.cs
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/MethodGroupTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Projectables.FunctionalTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using VerifyXunit;
+using Xunit;
+
+namespace EntityFrameworkCore.Projectables.FunctionalTests;
+
+[UsesVerify]
+public class MethodGroupTests
+{
+    public record Entity
+    {
+        public int Id { get; set; }
+
+        public List<Entity>? RelatedEntities { get; set; }
+    }
+
+    [Projectable]
+    public static int NextId(Entity entity) => entity.Id + 1;
+
+    [Fact]
+    public Task ProjectOverMethodGroup()
+    {
+        using var dbContext = new SampleDbContext<Entity>();
+
+        var query = dbContext.Set<Entity>()
+            .Select(x => new { NextIds = x.RelatedEntities!.Select(NextId) });
+
+        return Verifier.Verify(query.ToQueryString());
+    }
+}


### PR DESCRIPTION
This adds support for projecting method groups, closing #62.

For example:
```c#
[Projectable]
public static ProgramDto ProgramToDto(Program p) => new(
    p.Projects.Select(ProjectToDto),
```

There is a new test covering the basic functionality, and this change functions correctly in my own solution.  I wasn't able to create a scenario where `CreateDelegate` wasn't wrapped by a `Convert` expression, hence the long expression pattern.