### PR TITLE
Fix eager includes not working 

### DIFF
--- a/samples/BasicSample/Program.cs
+++ b/samples/BasicSample/Program.cs
@@ -200,6 +200,18 @@ namespace BasicSample
                 Console.WriteLine($"Our users bought the following products starting with 'Red': {string.Join(", ", result.Ordered)}");
             }
 
+            {
+                var ret = dbContext.Users
+                    .Include(x => x.Orders)
+                    .ThenInclude(x => x.Items)
+                    .ThenInclude(x => x.Product)
+                    .First();
+                Console.WriteLine($"User name: {ret.FullName}, Orders: {string.Join(", ", ret.Orders
+                    .SelectMany(x => x.Items
+                        .Select(y => y.Product.Name)
+                    ))}");
+            }
+
         }
     }
 }

--- a/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
+++ b/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
@@ -255,6 +255,9 @@ namespace EntityFrameworkCore.Projectables.Services
             var properties = entityType.GetProperties()
                 .Where(x => !x.IsShadowProperty())
                 .Select(x => x.GetMemberInfo(false, false))
+                .Concat(entityType.GetNavigations()
+                    .Where(x => !x.IsShadowProperty())
+                    .Select(x => x.GetMemberInfo(false, false)))
                 // Remove projectable properties from the ef properties. Since properties returned here for auto
                 // properties (like `public string Test {get;set;}`) are generated fields, we also need to take them into account.
                 .Where(x => projectableProperties.All(y => x.Name != y.Name && x.Name != $"<{y.Name}>k__BackingField"));

--- a/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
+++ b/src/EntityFrameworkCore.Projectables/Services/ProjectableExpressionReplacer.cs
@@ -59,6 +59,7 @@ namespace EntityFrameworkCore.Projectables.Services
         [return: NotNullIfNotNull(nameof(node))]
         public Expression? Replace(Expression? node)
         {
+            _disableRootRewrite = false;
             var ret = Visit(node);
 
             if (_disableRootRewrite)


### PR DESCRIPTION
Before this changes, doing:
```csharp
database.Users.Include(x => x.Orders).First()
```
resulted in a null Orders field. This fixes this issue.

This also fixes a bug where query rewriting would be disabled when it should not.