### PR TITLE
Use RegisterImplementationSourceOutput for perf

### DIFF
--- a/src/EntityFrameworkCore.Projectables.Generator/ProjectionExpressionGenerator.cs
+++ b/src/EntityFrameworkCore.Projectables.Generator/ProjectionExpressionGenerator.cs
@@ -51,7 +51,7 @@ namespace EntityFrameworkCore.Projectables.Generator
                 = context.CompilationProvider.Combine(memberDeclarations.Collect());
 
             // Generate the source using the compilation and enums
-            context.RegisterSourceOutput(compilationAndEnums,
+            context.RegisterImplementationSourceOutput(compilationAndEnums,
                 static (spc, source) => Execute(source.Item1, source.Item2, spc));
         }
 


### PR DESCRIPTION
By using [RegisterImplementationSourceOutput](https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md?plain=1#L905) we should see a significant code generation performance impact with no downsides.

Fixes #102 