### PR TITLE
Fix preview version names in release process.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           VERSION="${arrTag[2]}"
           echo Version: $VERSION
           CONFIGURATION="Release"
-          VERSION="${VERSION//v}"
+          VERSION="${VERSION#v}"
           echo Clean Version: $VERSION
           echo Configuration: $CONFIGURATION
           dotnet pack -v normal -c $CONFIGURATION --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg


### PR DESCRIPTION
In release action, remove 'v' only from the beginning of the version. Currently it's removing all letters 'v' from the version so `v4.0.0-preview.2` is published as `4.0.0-preiew.2`.

Found the solution using Chat GPT and this StackOverflow post: https://stackoverflow.com/questions/71630227/github-action-how-to-remove-starting-v-from-variable

Can't really test it, hopefully it works.

Closes #106.