### PR TITLE
Derived from QueryCompiler base class

### DIFF
--- a/src/EntityFrameworkCore.Projectables/Infrastructure/Internal/CustomQueryCompiler.cs
+++ b/src/EntityFrameworkCore.Projectables/Infrastructure/Internal/CustomQueryCompiler.cs
@@ -7,30 +7,38 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using EntityFrameworkCore.Projectables.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EntityFrameworkCore.Projectables.Infrastructure.Internal
 {
+    /// <summary>
+    /// Foo
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Needed")]
-    public sealed class CustomQueryCompiler : IQueryCompiler
+    public sealed class CustomQueryCompiler : QueryCompiler
     {
         readonly IQueryCompiler _decoratedQueryCompiler;
         readonly ProjectableExpressionReplacer _projectableExpressionReplacer;
 
-        public CustomQueryCompiler(IQueryCompiler decoratedQueryCompiler)
+        public CustomQueryCompiler(IQueryCompiler decoratedQueryCompiler, IQueryContextFactory queryContextFactory, ICompiledQueryCache compiledQueryCache, ICompiledQueryCacheKeyGenerator compiledQueryCacheKeyGenerator, IDatabase database, IDiagnosticsLogger<DbLoggerCategory.Query> logger, ICurrentDbContext currentContext, IEvaluatableExpressionFilter evaluatableExpressionFilter, IModel model) : base(queryContextFactory, compiledQueryCache, compiledQueryCacheKeyGenerator, database, logger, currentContext, evaluatableExpressionFilter, model)
         {
             _decoratedQueryCompiler = decoratedQueryCompiler;
             _projectableExpressionReplacer = new ProjectableExpressionReplacer(new ProjectionExpressionResolver());
         }
 
-        public Func<QueryContext, TResult> CreateCompiledAsyncQuery<TResult>(Expression query) 
+        public override Func<QueryContext, TResult> CreateCompiledAsyncQuery<TResult>(Expression query) 
             => _decoratedQueryCompiler.CreateCompiledAsyncQuery<TResult>(Expand(query));
-        public Func<QueryContext, TResult> CreateCompiledQuery<TResult>(Expression query) 
+        public override Func<QueryContext, TResult> CreateCompiledQuery<TResult>(Expression query) 
             => _decoratedQueryCompiler.CreateCompiledQuery<TResult>(Expand(query));
-        public TResult Execute<TResult>(Expression query)
+        public override TResult Execute<TResult>(Expression query)
             => _decoratedQueryCompiler.Execute<TResult>(Expand(query));
-        public TResult ExecuteAsync<TResult>(Expression query, CancellationToken cancellationToken)
+        public override TResult ExecuteAsync<TResult>(Expression query, CancellationToken cancellationToken)
             => _decoratedQueryCompiler.ExecuteAsync<TResult>(Expand(query), cancellationToken);
 
         Expression Expand(Expression expression)


### PR DESCRIPTION
Fixes #110 

By deriving from the base class instead of the interface, we inherit any future method required by EF Core 9