### PR TITLE
don't rewrite the query root when attempting to track the results

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100"
+    "version": "9.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/EntityFrameworkCore.Projectables/Extensions/ExpressionExtensions.cs
+++ b/src/EntityFrameworkCore.Projectables/Extensions/ExpressionExtensions.cs
@@ -18,6 +18,6 @@ namespace EntityFrameworkCore.Projectables.Extensions
         /// Replaces all calls to properties and methods that are marked with the <C>Projectable</C> attribute with their respective expression tree
         /// </summary>
         public static Expression ExpandProjectables(this Expression expression)
-            => new ProjectableExpressionReplacer(new ProjectionExpressionResolver()).Replace(expression);
+            => new ProjectableExpressionReplacer(new ProjectionExpressionResolver(), false).Replace(expression);
     }
 }

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/ChangeTrackerTests.cs
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/ChangeTrackerTests.cs
@@ -1,0 +1,76 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Projectables.FunctionalTests.Helpers;
+using EntityFrameworkCore.Projectables.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EntityFrameworkCore.Projectables.FunctionalTests;
+
+public class ChangeTrackerTests
+{
+    public class SqliteSampleDbContext<TEntity> : DbContext
+        where TEntity : class
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlite("Data Source=test.sqlite");
+            optionsBuilder.UseProjectables();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TEntity>();
+        }
+    }
+
+    public record Entity
+    {
+        private static int _nextId = 1;
+        public const int Computed1DefaultValue = -1;
+        public int Id { get; set; } = _nextId++;
+        public string? Name { get; set; }
+
+        [Projectable(UseMemberBody = nameof(InternalComputed1))]
+        public int Computed1 { get; set; } = Computed1DefaultValue;
+        private int InternalComputed1 => Id;
+
+        [Projectable]
+        public int Computed2 => Id * 2;
+    }
+
+    [Fact]
+    public async Task CanQueryAndChangeTrackedEntities()
+    {
+        using var dbContext = new SqliteSampleDbContext<Entity>();
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+        dbContext.Add(new Entity());
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+
+        var entity = await dbContext.Set<Entity>().AsTracking().FirstAsync();
+        var entityEntry = dbContext.ChangeTracker.Entries().Single();
+        Assert.Same(entityEntry.Entity, entity);
+        dbContext.Set<Entity>().Remove(entity);
+        await dbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task CanSaveChanges()
+    {
+        using var dbContext = new SqliteSampleDbContext<Entity>();
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+        dbContext.Add(new Entity());
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+
+        var entity = await dbContext.Set<Entity>().AsTracking().FirstAsync();
+        entity.Name = "test";
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        var entity2 = await dbContext.Set<Entity>().FirstAsync();
+        Assert.Equal("test", entity2.Name);
+    }
+}

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/EntityFrameworkCore.Projectables.FunctionalTests.csproj
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/EntityFrameworkCore.Projectables.FunctionalTests.csproj
@@ -11,7 +11,8 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
 	<PackageReference Include="ScenarioTests.XUnit" />
 	<PackageReference Include="Verify.Xunit" />
 	<PackageReference Include="xunit" />

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/Helpers/SampleDbContext.cs
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/Helpers/SampleDbContext.cs
@@ -14,10 +14,12 @@ namespace EntityFrameworkCore.Projectables.FunctionalTests.Helpers
         where TEntity : class
     {
         readonly CompatibilityMode _compatibilityMode;
+        readonly QueryTrackingBehavior _queryTrackingBehavior;
 
-        public SampleDbContext(CompatibilityMode compatibilityMode = CompatibilityMode.Full)
+        public SampleDbContext(CompatibilityMode compatibilityMode = CompatibilityMode.Full, QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
         {
             _compatibilityMode = compatibilityMode;
+            _queryTrackingBehavior = queryTrackingBehavior;
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -26,6 +28,7 @@ namespace EntityFrameworkCore.Projectables.FunctionalTests.Helpers
             optionsBuilder.UseProjectables(options => {
                 options.CompatibilityMode(_compatibilityMode); // Needed by our ComplexModelTests
             });
+            optionsBuilder.UseQueryTrackingBehavior(_queryTrackingBehavior);
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsNoTrackingQueryRootExpression.DotNet9_0.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsNoTrackingQueryRootExpression.DotNet9_0.verified.txt
@@ -1,0 +1,2 @@
+﻿SELECT [e].[Id], [e].[Id] * 5
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsNoTrackingQueryRootExpression.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsNoTrackingQueryRootExpression.verified.txt
@@ -1,0 +1,2 @@
+﻿SELECT [e].[Id], [e].[Id] * 5
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsTrackingQueryRootExpression.DotNet9_0.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsTrackingQueryRootExpression.DotNet9_0.verified.txt
@@ -1,0 +1,2 @@
+﻿SELECT [e].[Id]
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsTrackingQueryRootExpression.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.AsTrackingQueryRootExpression.verified.txt
@@ -1,0 +1,2 @@
+﻿SELECT [e].[Id]
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.DontUseMemberPropertyQueryRootExpression.DotNet9_0.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.DontUseMemberPropertyQueryRootExpression.DotNet9_0.verified.txt
@@ -1,0 +1,2 @@
+﻿SELECT [e].[Id]
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.DontUseMemberPropertyQueryRootExpression.verified.txt
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.DontUseMemberPropertyQueryRootExpression.verified.txt
@@ -1,0 +1,2 @@
+﻿SELECT [e].[Id]
+FROM [Entity] AS [e]

--- a/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.cs
+++ b/tests/EntityFrameworkCore.Projectables.FunctionalTests/QueryRootTests.cs
@@ -26,7 +26,17 @@ namespace EntityFrameworkCore.Projectables.FunctionalTests
         [Fact]
         public Task UseMemberPropertyQueryRootExpression()
         {
-            using var dbContext = new SampleDbContext<Entity>();
+            using var dbContext = new SampleDbContext<Entity>(queryTrackingBehavior: QueryTrackingBehavior.NoTracking);
+
+            var query = dbContext.Set<Entity>();
+
+            return Verifier.Verify(query.ToQueryString());
+        }
+
+        [Fact]
+        public Task DontUseMemberPropertyQueryRootExpression()
+        {
+            using var dbContext = new SampleDbContext<Entity>(queryTrackingBehavior: QueryTrackingBehavior.TrackAll);
 
             var query = dbContext.Set<Entity>();
 
@@ -44,6 +54,26 @@ namespace EntityFrameworkCore.Projectables.FunctionalTests
 
             var query = original
                 .Select(e => new { Item = e, TotalCount = original.Count() });
+
+            return Verifier.Verify(query.ToQueryString());
+        }
+
+        [Fact]
+        public Task AsTrackingQueryRootExpression()
+        {
+            using var dbContext = new SampleDbContext<Entity>(queryTrackingBehavior: QueryTrackingBehavior.NoTracking);
+
+            var query = dbContext.Set<Entity>().AsTracking();
+
+            return Verifier.Verify(query.ToQueryString());
+        }
+
+        [Fact]
+        public Task AsNoTrackingQueryRootExpression()
+        {
+            using var dbContext = new SampleDbContext<Entity>(queryTrackingBehavior: QueryTrackingBehavior.TrackAll);
+
+            var query = dbContext.Set<Entity>().AsNoTracking();
 
             return Verifier.Verify(query.ToQueryString());
         }


### PR DESCRIPTION
closes #129 

The issue is that you can't query entities and have them be tracked, so this fails:
```C#
var entity = db.Entities.First();
db.Remove(entity);//throws because entity isn't tracked
```

This is because `db.Entities.First()` is rewritten into `db.Entities.Select(e => new Entity { ...e }).First()` and this breaks entity tracking.

So I introduced some fixes so that if tracking was going to happen then it wouldn't be rewritten. This is determined via the default tracking behavior, configured like:
```C#
optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.TrackAll); //default value shown
```
or based on if `AsTracking` or AsNoTracking` is part of the query, eg:
```C#
var entity = db.Entities.AsTracking().First();//query is not rewritten
var entity = db.Entities.AsNoTracking().First();//query is rewritten
```
default applies first and can be overridden by using `AsTracking` or `AsNoTracking` explicitly. So if you want root rewriting by default, then I suggest you set the default tracking behavior to `NoTracking` and everything will keep working as it does in the current release. If however you use tracking by default, then you can call `AsNoTracking` or `ExpandProjectables` to rewrite the root query.